### PR TITLE
Amélioration de l'aide Markdown

### DIFF
--- a/templates/markdown.html
+++ b/templates/markdown.html
@@ -6,48 +6,75 @@
 {% block content %}
 
 <div class="row">
-  <div class="large-8 medium-12 columns">
+  <div class="large-12 medium-12 columns">
     <h1>Markdown</h1>
-    <p>DocHub utilise du Markdown dans les discussions et les descriptions des documents.</p>
-    <h3>Le Markdown c'est quoi ?</h3>
+    <p>DocHub utilise Markdown pour mettre en forme les discussions et les descriptions des documents.</p>
+    <h2>Le Markdown c'est quoi ?</h2>
     <p>
-      Le Markdown est un "language" servant à formatter du texte. A la place d'avoir un texte morne et sans mise en page, grâce au Markdown vous pouvez mettre des titres, des images, des listes et encore d'autres choses dans vos textes.<br>
+      Markdown est une convention permettant une mise en page structurée grâce à des annotations simples dans le texte. Vous pouvez par exemple ajouter des titres, des images, des listes et encore d'autres choses dans vos textes.<br>
+      Markdown a l'avantage d'être facile à lire aussi bien en texte que lorsqu'il est mis en page, et apprendre ses conventions ne devrait vous prendre plus que quelques minutes. <br>
       <small>Vous ne voulez pas l'utiliser ? Pas de problème, faites comme si il n'existait pas, vous pouvez taper du texte normalement comme vous l'avez toujours fait.</small>
     </p>
-    <p>
-      <h3>Titres</h3>
-      Vous pouvez écrire un titre en ajoutant le symbole <code>#</code> au début de la ligne. Au plus vous ajoutez de <code>#</code> consécutifs, au plus le titre sera petit. (Vous pouvez en ajouter 5 au maximum)<br>
-      <pre class="codehilite"># Un grand titre
-## Un titre un peu plus petit
-##### Un très petit titre</pre>
-      <h3>Citations</h3>
-      Pour citer un texte, il suffit de rajouter un <code>></code> devant chaque ligne.
-      <pre class="codehilite">Comme le disait Mao :
-> Manger c'est tricher, mais tricher, c'est gagner.</pre>
-      <h3>Gras et italique</h3>
-      Vous pouvez rendre votre texte en gras ou en italique en entourant la partie concernée par des <code>*</code> (simples pour l'italique, double pour le gras).
-      <pre class="codehilite">Ceci est un texte avec de l'*italique* et des **phrases en gras**</pre>
-      <h3>Liens et images</h3>
-      Markdown supporte aussi les liens et images.<br>
-      Un lien s'écrit de la manière suivante <code>[Texte du lien](http://site-web.com)</code>.
-      <pre class="codehilite">Je vous conseille fortement d'aller vérifier
-vos points sur [l'université virtuelle](http://uv.ulb.ac.be)</pre>
-      L'ajout d'images se fait de manière assez semblable : <code>![](http://example.com/image-a-afficher.jpg)</code>
-      <pre class="codehilite">Le logo de l'ULB ressemble à ça : ![](http://www.ulb.ac.be/dre/com/docs/logo3lpbp.jpg)</pre>
-      <h3>Listes</h3>
-      Vous pouvez aussi ajouter des listes (à puce ou numérotées)
-      <pre class="codehilite">Liste à puce :
+    <h2>Titres</h2>
+    <p>Vous pouvez écrire un titre en ajoutant le symbole <code>#</code> au début de la ligne. Au plus vous ajoutez de <code>#</code> consécutifs, au plus le titre sera petit. (Vous pouvez en ajouter 5 au maximum)</p>
+    {% markdown_demo %}
+    # Titre principal
+    ## Sous titre
+    ##### Titre insignifiant
+    {% end_markdown_demo %}
 
-* élément
-* élément
-* élément
+    <h2>Citations</h2>
+    <p>Pour citer un texte, il suffit de rajouter un <code>></code> devant chaque ligne.</p>
+    {% markdown_demo %}
+    Comme disait Mao :
+    > Manger c'est tricher, mais tricher, c'est gagner.
+    {% end_markdown_demo %}
 
-Liste numérotée :
+    <h2>Gras et italique</h2>
+    <p>Vous pouvez rendre votre texte en gras ou en italique en entourant la partie concernée par des <code>*</code> (simples pour l'italique, double pour le gras).</p>
+    {% markdown_demo %}
+    Avec *une étoile, c'est du texte en italique*, 
+    mais avec **deux étoiles, c'est du texte en gras**
+    {% end_markdown_demo %}
 
-1. élément 1
-2. élément 2
-3. élément 3</pre>
-    </p>
+    <h2>Liens et images</h2>
+    <p>Markdown supporte aussi les liens et images.<br>
+    Un lien s'écrit de la manière suivante <code>[Texte du lien](http://site-web.com)</code>.</p>
+    {% markdown_demo %}
+    Les points sont disponibles sur [l'université virtuelle](http://uv.ulb.ac.be)
+    {% end_markdown_demo %}
+
+    <p>L'ajout d'images se fait de manière assez semblable : <code>![titre](http://example.com/image-a-afficher.jpg)</code> (notez le point d'exclamation au début)</p>
+    {% markdown_demo %}
+    ![logo ULB](http://www.ulb.ac.be/dre/com/docs/logo3lpbp.jpg) notre alma mater
+    {% end_markdown_demo %}
+    
+    <h2>Listes</h2>
+    <p>Vous pouvez aussi ajouter des listes (à puce ou numérotées)</p>
+    {% markdown_demo %}
+    * Une puce
+    * Une autre puce
+    * Encore une autre puce
+
+    Liste numérotée :
+
+    1. Premier élément
+    2. Second élément
+    3. Troisième élément
+    {% end_markdown_demo %}
+
+    <h2>Formules mathématiques</h2>
+    <p>Vous pouvez même insérer des formules mathématiques en utilisant la notation $\LaTeX$, encadrée par des <code>$</code>. La notation mathématique $\LaTeX$ est bien trop complète pour être décrite ici, mais il existe un <a target="_blank" href="https://fr.wikibooks.org/wiki/LaTeX/Math%C3%A9matiques">excellent Wikilivre</a> à ce sujet.</p>
+    {% markdown_demo %}
+    La tranformée de Fourier de $f(x)$ est $F(\theta) = \int_{-\infty}^{+\infty} f(x)e^{i\theta x} \mathrm dx$
+
+    La factorielle est définie comme 
+    $n! = \begin{cases}
+      1 & n \leq 1 \\
+      n\times(n-1)! & n \gt 1
+    \end{cases}$
+    {% end_markdown_demo %}
+
     <h1 id="memory">Aide-mémoire</h1>
     {% include "markdown_cheatsheet.html" %}
   </div>

--- a/templates/markdown_cheatsheet.html
+++ b/templates/markdown_cheatsheet.html
@@ -1,4 +1,7 @@
-<pre class="codehilite"># Un grand titre
+{% load custommardown %}
+
+{% markdown_demo %}
+# Un grand titre
 ## Un titre un peu plus petit
 ##### Un très petit titre
 
@@ -9,7 +12,7 @@ Texte avec de l'*italique* et des **mots en gras**
 
 [Texte du lien](http://site-web.com)
 
-![](http://example.com/image-a-afficher.jpg)
+![Python, c'est génial !](http://imgs.xkcd.com/comics/python.png)
 
 Liste à puce :
 
@@ -21,4 +24,15 @@ Liste numérotée :
 
 1. élément 1
 2. élément 2
-3. élément 3</pre>
+3. élément 3
+
+Maths :
+$F(\theta) = \int_{-\infty}^{+\infty} f(x)e^{i\theta x} \mathrm dx$
+
+$
+n! = \begin{cases}
+1 & n \leq 1 \\
+n\times(n-1)! & n \gt 1
+\end{cases}
+$
+{% end_markdown_demo %}


### PR DESCRIPTION
Création d'un template tag django `mardown_demo` permettant la mise en page du markdown et de son rendu en onglets, et amélioration des pages d'aide markdown grâce à ce tag
