### PR TITLE
[enh] Add file size and type in document serializer

### DIFF
--- a/documents/serializers.py
+++ b/documents/serializers.py
@@ -14,6 +14,7 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
 
     user_vote = serializers.SerializerMethodField()
     has_perm = serializers.SerializerMethodField()
+    file_size = serializers.SerializerMethodField()
 
     def get_user_vote(self, document):
         user = self.context['request'].user
@@ -39,12 +40,15 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
         user = self.context['request'].user
         return user.write_perm(obj=document)
 
+    def get_file_size(self, document):
+        return document.original.size
+
     class Meta:
         model = Document
         fields = (
-            'course', 'date', 'description', 'downloads', 'file_type',
-            'has_perm', 'hidden', 'id', 'is_processing', 'is_ready',
-            'is_unconvertible', 'md5', 'name', 'pages', 'size', 'state',
+            'course', 'date', 'description', 'downloads', 'file_size',
+            'file_type', 'has_perm', 'hidden', 'id', 'is_processing',
+            'is_ready', 'is_unconvertible', 'md5', 'name', 'pages', 'state',
             'tags', 'url', 'user', 'user_vote', 'views', 'votes',
         )
 

--- a/documents/serializers.py
+++ b/documents/serializers.py
@@ -12,8 +12,8 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     tags = TagSerializer(many=True)
     user = SmallUserSerializer()
 
-    has_perm = serializers.SerializerMethodField()
     user_vote = serializers.SerializerMethodField()
+    has_perm = serializers.SerializerMethodField()
 
     def get_user_vote(self, document):
         user = self.context['request'].user
@@ -42,11 +42,10 @@ class DocumentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Document
         fields = (
-            'id', 'name', 'url', 'course', 'description',
-            'user', 'pages', 'date', 'views', 'user_vote', 'votes',
-            'downloads', 'state', 'md5', 'tags', 'has_perm',
-            'is_unconvertible', 'is_ready', 'is_processing',
-            'hidden',
+            'course', 'date', 'description', 'downloads', 'file_type',
+            'has_perm', 'hidden', 'id', 'is_processing', 'is_ready',
+            'is_unconvertible', 'md5', 'name', 'pages', 'size', 'state',
+            'tags', 'url', 'user', 'user_vote', 'views', 'votes',
         )
 
         extra_kwargs = {


### PR DESCRIPTION
This is required in order to have proper file extensions and implement the `stat` syscall in the [FUSE interface for Dochub](https://github.com/titouanc/docfub)

*+sort fields (I have OCDs !)*