### PR TITLE
Fix the tag filtering on the course page

### DIFF
--- a/catalog/templates/catalog/course.html
+++ b/catalog/templates/catalog/course.html
@@ -105,7 +105,7 @@
                     class="border-top p-2 d-flex align-items-center"
                     data-course-filter-target="filterable"
                     data-filter-key='{{ document.name }}'
-                    data-tags="{{ tags|join:' ' }}"
+                    data-tags="{{ document.tags.all|join:' ' }}"
                 >
 
                     <a href="{% url 'document_show' document.pk %}"


### PR DESCRIPTION
One liner fix for a stupid mistake (all documents were given all tags in the view so the filtering was always showing every document)