### PR TITLE
Try fixing some errors from hotwire on sentry by using a hack to use 7.2.0

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,6 +1,5 @@
 import _ from 'https://cdn.skypack.dev/lodash';
 
-import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo@v7.2.0-rc.3'; // FIXME upgrade to 7.2.0 when skypack is fixed https://github.com/skypackjs/skypack-cdn/issues/319
 import {Controller, Application} from 'https://cdn.skypack.dev/@hotwired/stimulus';
 import { Autocomplete } from 'https://cdn.skypack.dev/stimulus-autocomplete';
 

--- a/www/templates/base.html
+++ b/www/templates/base.html
@@ -11,6 +11,11 @@
             rel="stylesheet" crossorigin="anonymous"
             integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor">
         <script type="module" src="{% static "main.js" %}" defer></script>
+        <!--
+        See https://github.com/hotwired/turbo/issues/735#issuecomment-1257143652
+        and https://github.com/skypackjs/skypack-cdn/issues/319
+        -->
+        <script src="https://cdn.jsdelivr.net/npm/@hotwired/turbo@7.2.0/dist/turbo.es2017-umd.min.js" async type="text/javascript"></script>
         <script type="module" src="{% static "sentry.js" %}" defer></script>
         <script defer data-domain="dochub.be" src="https://stats.dochub.be/js/plausible.js"></script>
 


### PR DESCRIPTION
We were locked on 7.2.0-rc2 before as there is a bug in skypack (see skypackjs/skypack-cdn#319).  By using [this](https://github.com/hotwired/turbo/issues/735#issuecomment-1257143652) hack, we can upgrade to 7.2.0 and hope the issues will be solved (as hotwired/turbo#253 suggests)

This might fix DOCHUB-1P6.