### PR TITLE
Do not try to initialize sentry if we have no DSN 

### DIFF
--- a/static/sentry.js
+++ b/static/sentry.js
@@ -4,10 +4,12 @@ import { BrowserTracing } from "https://cdn.skypack.dev/@sentry/tracing";
 const head = document.querySelector("head");
 const DSN = head.dataset.sentryDsn;
 
-Sentry.init({
-    dsn: DSN,
-    integrations: [new BrowserTracing()],
-    release: head.dataset.sentryRelease,
-});
+if (DSN.length > 0 && DSN.startsWith("https://")) {
+    Sentry.init({
+        dsn: DSN,
+        integrations: [new BrowserTracing()],
+        release: head.dataset.sentryRelease,
+    });
 
-Sentry.setUser({ email: head.dataset.sentryEmail });
+    Sentry.setUser({ email: head.dataset.sentryEmail });
+}


### PR DESCRIPTION
(useful to avoid warnings while developing on your machine without having a DSN)