### PR TITLE
Ensure the tests are running with DEBUG=False

### DIFF
--- a/www/settings.py
+++ b/www/settings.py
@@ -206,3 +206,10 @@ try:
     from .local_settings import *
 except ImportError:
     pass
+
+
+if DEBUG:
+    print(
+        "Warning: you are running Dochub with DEBUG=True. This is dangerous if your server is publicly accessible."
+    )
+    print("You should set DEBUG=False in production.\n\n")

--- a/www/settings.py
+++ b/www/settings.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import environ
@@ -147,6 +148,19 @@ CACHES = {"default": env.cache_url("CACHE_URL", default="dummycache://")}
 SENTRY_DSN = env("SENTRY_DSN", default=None)
 SENTRY_RELEASE = get_default_release()
 
+# Only configure S3 storage if we have a STORAGE_ENDPOINT env variable else, default to the local filesystem
+if env("STORAGE_ENDPOINT", default=None):
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+
+    # https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+    AWS_S3_ENDPOINT_URL = env("STORAGE_ENDPOINT")
+    AWS_S3_ACCESS_KEY_ID = env("STORAGE_ACCESS_KEY")
+    AWS_S3_SECRET_ACCESS_KEY = env("STORAGE_SECRET_KEY")
+    AWS_STORAGE_BUCKET_NAME = env("STORAGE_MEDIA_BUCKET_NAME")
+elif not DEBUG:
+    print("Warning: no storage configured but DEBUG=False, using local filesystem.")
+    print("You DO NOT want this in production!")
+
 if DEBUG:
     INSTALLED_APPS.extend(["django_extensions"])
 
@@ -181,13 +195,6 @@ else:
     STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
     WHITENOISE_ROOT = BASE_DIR / "static" / "root"
 
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-
-    # https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
-    AWS_S3_ENDPOINT_URL = env("STORAGE_ENDPOINT")
-    AWS_S3_ACCESS_KEY_ID = env("STORAGE_ACCESS_KEY")
-    AWS_S3_SECRET_ACCESS_KEY = env("STORAGE_SECRET_KEY")
-    AWS_STORAGE_BUCKET_NAME = env("STORAGE_MEDIA_BUCKET_NAME")
 
 READ_ONLY = False
 REJECTED_FILE_FORMATS = (".zip", ".tar", ".gz", ".rar")

--- a/www/test_settings.py
+++ b/www/test_settings.py
@@ -22,5 +22,8 @@ CELERY_ALWAYS_EAGER = True  # Skip the Celery daemon
 # which emulates the API and behavior of AsyncResult,
 # except the result is already evaluated.
 
+# Required if we don't want to build the collected static files upfront
+# (which is not possible desirable to do before each test run)
+WHITENOISE_MANIFEST_STRICT = False
 
 UPLOAD_DIR = tempfile.mkdtemp()

--- a/www/test_settings.py
+++ b/www/test_settings.py
@@ -1,4 +1,17 @@
+import os
 import tempfile
+
+# We want DocHub to run in DEBUG=True by default so a user cloning the repo
+# can run the app without any configuration and still have some DEBUG info.
+# However, we don't want to run the tests in DEBUG=True mode, so we override
+if "DEBUG" not in os.environ:
+    os.environ["DEBUG"] = "False"
+
+    # We do not want to run in DEBUG=False without an explicit SECRET_KEY
+    # (it's too risky to forget setting it in production)
+    # But we allow the exception in the tests (and only in the tests)
+    if "SECRET_KEY" not in os.environ:
+        os.environ["SECRET_KEY"] = "this-is-a-secret-key-to-be-used-in-tests"
 
 from www.settings import *
 
@@ -8,8 +21,6 @@ CELERY_ALWAYS_EAGER = True  # Skip the Celery daemon
 # apply_async() and Task.delay() will return an EagerResult instance,
 # which emulates the API and behavior of AsyncResult,
 # except the result is already evaluated.
-
-DEBUG = False
 
 
 UPLOAD_DIR = tempfile.mkdtemp()

--- a/www/test_settings.py
+++ b/www/test_settings.py
@@ -9,5 +9,7 @@ CELERY_ALWAYS_EAGER = True  # Skip the Celery daemon
 # which emulates the API and behavior of AsyncResult,
 # except the result is already evaluated.
 
+DEBUG = False
+
 
 UPLOAD_DIR = tempfile.mkdtemp()

--- a/www/tests/test_settings.py
+++ b/www/tests/test_settings.py
@@ -2,4 +2,4 @@ from www import settings
 
 
 def test_no_debug():
-    assert settings.DEBUG == False
+    assert settings.DEBUG is False

--- a/www/tests/test_settings.py
+++ b/www/tests/test_settings.py
@@ -1,0 +1,5 @@
+from www import settings
+
+
+def test_no_debug():
+    assert settings.DEBUG == False


### PR DESCRIPTION
As @Mortinat said, the tests should run with `DEBUG = False` to ensure we are as close as production as possible.
This does set  `DEBUG = False` and also ensures with a test is stays `False` in the event that the settings are changed or our tests setup changes.


This PR has the following benefits:
* Minimal changes
* For a new user/new clone: DEBUG=True: this helps a lot for the initial ./manage.py runserver (if there is a problem, Django show a helpful page and not a 500 error with no explanation)
* The secret key stays required if DEBUG=False so we don't have the risk of forgetting to set the secret key in production (that would be very bad)