### PR TITLE
Run tests on github actions both for sqlite and postgresql

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -10,6 +10,18 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+
     steps:
     - uses: actions/checkout@v3
     - name: Apt update
@@ -44,8 +56,13 @@ jobs:
     - name: Statics checks
       run: ./manage.py collectstatic --noinput -v 0
 
-    - name: pytest
+    - name: pytest with SQLite
       run: pytest -k "not unoconv"
 
-    - name: database checks
+    - name: pytest with PostgreSQL
+      run: pytest -k "not unoconv" -m postgresql
+      env:
+        DB_URL: postgres://postgresql:postgresql@postgresql:5432/postgresql
+
+    - name: Check local dev initialization scripts
       run: make database

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -62,7 +62,7 @@ jobs:
     - name: pytest with PostgreSQL
       run: pytest -k "not unoconv" -m postgresql
       env:
-        DB_URL: postgres://postgresql:postgresql@postgresql:5432/postgresql
+        DB_URL: postgres://postgres:postgres@postgres:5432/postgres
 
     - name: Check local dev initialization scripts
       run: make database

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,6 +20,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
 
 
     steps:
@@ -62,7 +65,7 @@ jobs:
     - name: pytest with PostgreSQL
       run: pytest -k "not unoconv" -m postgresql
       env:
-        DB_URL: postgres://postgres:postgres@postgres:5432/postgres
+        DB_URL: postgres://postgres:postgres@localhost:5432/postgres
 
     - name: Check local dev initialization scripts
       run: make database

--- a/search/tests/test_postgresql.py
+++ b/search/tests/test_postgresql.py
@@ -1,0 +1,28 @@
+from django.db import connection
+
+import pytest
+
+
+def needs_postgres(fn):
+    @pytest.mark.django_db
+    @pytest.mark.postgresql
+    @pytest.mark.skipif(
+        connection.vendor != "postgresql",
+        reason="This test requires a PostgreSQL database",
+    )
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@needs_postgres
+def test_running_with_postgres():
+    """
+    This is a dummy test to check if our logic of @needs_postgres is correct
+    and that the setup of GitHub actions is correct too.
+    """
+    assert True
+
+
+# FIXME: add more tests (see https://github.com/UrLab/DocHub/issues/257)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ markers =
     unoconv: uses unoconv (underterministic)
     webtest: http queries against localhost
     celery: uses celery tasks
+    postgresql: needs a postgresql database to run
 
 [flake8]
 ignore = E261


### PR DESCRIPTION
For now, we only run a dummy test with the postgresql backend (and this test is skipped when running with sqlite) but the framework is set so somebody can write more complex tests later (see #257)