### PR TITLE
Use the pre-commit/action github action instead of doing it by hand

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,8 +6,14 @@ on:
   pull_request:
 
 jobs:
-  build:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
 
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,12 +26,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-
-    - name: Install pre-commit
-      run: pip install pre-commit
-
-    - name: Check pre-commit
-      run: pre-commit run --all-files
 
     - name: Install python packages
       run: |


### PR DESCRIPTION
We were running `pre-commit run --all` "manually" as a step in GitHub actions. This is not desirable. Good catch by @Mortinat !
This PR uses the dedicated `pre-commit/action` github action instead

This will:
* Run the pre-commit checks in // of the other checks (we should gain a bit of time)
* Should improve the readability of the output
* Speed up the time to run pre-commit as the action uses some clever caching


![image](https://user-images.githubusercontent.com/85785/197594553-0e4e6e22-9f87-4449-bac8-5e5e2fb58cfd.png)


Edit: confirmation: 34s pour avoir le retour du job de pre-commit (et 50s en moins dans le job de tests)
