### PR TITLE
Urgent: fix a memory hog when rendering a big pdf

### DIFF
--- a/www/templates/base.html
+++ b/www/templates/base.html
@@ -129,6 +129,11 @@
                 }
             }
 
+            .page-wrapper {
+                border: 1px solid #eee;
+                margin-bottom: 1em;
+            }
+
 
         </style>
         {% block head %}{% endblock %}


### PR DESCRIPTION
Fix the configuration of the IntersectionObserver to detect the pages that are visible so we can avoid rendering the invisible pages in the initial rendering as well as when scrolling.

Most important change is the removal of L122. The rest is refactoring that helps debugging the issue as well a better logging to understand it better.