### PR TITLE
fix: resolve bulk upload Turbo error with PRG pattern

### DIFF
--- a/documents/forms.py
+++ b/documents/forms.py
@@ -61,7 +61,7 @@ class BulkFilesForm(forms.Form):
             }
         ),
         error_messages={
-            "invalid": "Le lien fourni n'est pas valide. Veuillez entrer une URL complète (ex: https://...)."
+            "invalid": "Le lien fourni n'est pas valide. Entre une URL complète (ex: https://...)."
         },
     )
 

--- a/documents/forms.py
+++ b/documents/forms.py
@@ -52,7 +52,18 @@ class UploadFileForm(DocumentForm):
 
 
 class BulkFilesForm(forms.Form):
-    url = forms.URLField()
+    url = forms.URLField(
+        widget=forms.URLInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "https://...",
+                "id": "url",
+            }
+        ),
+        error_messages={
+            "invalid": "Le lien fourni n'est pas valide. Veuillez entrer une URL complète (ex: https://...)."
+        },
+    )
 
 
 class ReUploadForm(forms.Form):

--- a/documents/templates/documents/document_upload.html
+++ b/documents/templates/documents/document_upload.html
@@ -196,6 +196,15 @@
           method="post">
         {% csrf_token %}
 
+        {% if request.GET.error == 'bulk' %}
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16">
+                    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+                </svg>
+                Le lien fourni n'est pas valide. Veuillez entrer une URL complète (ex: https://...).
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endif %}
         <div class="mb-3">
             <label for="url" class="form-label d-flex align-items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"

--- a/documents/templates/documents/document_upload.html
+++ b/documents/templates/documents/document_upload.html
@@ -193,18 +193,19 @@
 
     <form class="mt-5 text-muted"
           action="{% url 'document_submit_bulk' course.slug %}"
-          method="post">
-        {% csrf_token %}
+          method="post"
+          novalidate> {% csrf_token %}
 
-        {% if request.GET.error == 'bulk' %}
+        {% if bulk_form.url.errors %}
             <div class="alert alert-danger alert-dismissible fade show" role="alert">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16">
                     <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
                 </svg>
-                Le lien fourni n'est pas valide. Veuillez entrer une URL complète (ex: https://...).
+                {{ bulk_form.url.errors.0 }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         {% endif %}
+
         <div class="mb-3">
             <label for="url" class="form-label d-flex align-items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
@@ -215,20 +216,18 @@
                         d="M14 4.5V14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5zm-3 0A1.5 1.5 0 0 1 9.5 3V1h-2v1h-1v1h1v1h-1v1h1v1H6V5H5V4h1V3H5V2h1V1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V4.5h-2z"/>
                 </svg>
                 <div>
-                    Tu as beaucoup de documents à ajouter à la fois ? Par exemple un gros .zip sur WeTransfer ou une
-                    Dropbox ?<br/>
-                    Rentre ici l'adresse à laquelle Dochub peut trouver tes fichiers et tout sera ajouté automatiquement
-                    !
+                    Tu as beaucoup de documents à ajouter à la fois ? Par exemple un gros .zip sur WeTransfer ou une Dropbox ?<br/>
+                    Rentre ici l'adresse à laquelle Dochub peut trouver tes fichiers et tout sera ajouté automatiquement !
                 </div>
             </label>
             <div class="d-flex gap-2">
-                <div class="flex-grow-1"><input type="text" id="url" name="url" class="form-control"
-                                                placeholder="http://"></div>
+                <div class="flex-grow-1">
+                    {{ bulk_form.url }}
+                </div>
                 <button type="submit" class="btn btn-primary mb-2">Envoyer</button>
             </div>
             <div class="form-text">
-                Si ton lien contient un dossier séparé par cours, les fichiers seront automatiquement ajoutés dans le
-                bon cours.
+                Si ton lien contient un dossier séparé par cours, les fichiers seront automatiquement ajoutés dans le bon cours.
             </div>
         </div>
     </form>

--- a/documents/views.py
+++ b/documents/views.py
@@ -308,13 +308,17 @@ def submit_bulk(request, slug):
             BulkDocuments.objects.create(
                 url=form.cleaned_data["url"], course=course, user=request.user
             )
-
-            success_url = (
-                reverse("document_submit_bulk", args=[course.slug]) + "?success=1"
+            success_url = reverse(
+                "document_submit_bulk", args=[course.slug], query={"success": ""}
             )
             return HttpResponseRedirect(success_url)
+        else:
+            error_url = reverse(
+                "document_put", args=[course.slug], query={"error": "bulk"}
+            )
+            return HttpResponseRedirect(error_url)
 
-    if request.GET.get("success") == "1":
+    if "success" in request.GET:
         return render(
             request,
             "documents/document_bulk.html",

--- a/documents/views.py
+++ b/documents/views.py
@@ -309,13 +309,19 @@ def submit_bulk(request, slug):
                 url=form.cleaned_data["url"], course=course, user=request.user
             )
 
-            return render(
-                request,
-                "documents/document_bulk.html",
-                {
-                    "course": course,
-                },
+            success_url = (
+                reverse("document_submit_bulk", args=[course.slug]) + "?success=1"
             )
+            return HttpResponseRedirect(success_url)
+
+    if request.GET.get("success") == "1":
+        return render(
+            request,
+            "documents/document_bulk.html",
+            {
+                "course": course,
+            },
+        )
 
     return HttpResponseRedirect(reverse("document_put", args=[course.slug]))
 

--- a/documents/views.py
+++ b/documents/views.py
@@ -68,6 +68,7 @@ def upload_file(request, slug):
         form = UploadFileForm()
 
     multiform = MultipleUploadFileForm()
+    bulk_form = BulkFilesForm()
 
     return render(
         request,
@@ -75,6 +76,7 @@ def upload_file(request, slug):
         {
             "form": form,
             "multiform": multiform,
+            "bulk_form": bulk_form,
             "course": course,
         },
     )
@@ -305,18 +307,49 @@ def submit_bulk(request, slug):
         form = BulkFilesForm(request.POST)
 
         if form.is_valid():
-            BulkDocuments.objects.create(
-                url=form.cleaned_data["url"], course=course, user=request.user
-            )
-            success_url = reverse(
-                "document_submit_bulk", args=[course.slug], query={"success": ""}
+            url = form.cleaned_data["url"]
+
+            # Verify Duplicate Submission URL
+            if BulkDocuments.objects.filter(
+                url=url, course=course, processed=False
+            ).exists():
+                form.add_error(
+                    "url",
+                    "Ce lien a déjà été soumis pour ce cours et est en attente de traitement.",
+                )
+                return render(
+                    request,
+                    "documents/document_upload.html",
+                    {
+                        "course": course,
+                        "form": UploadFileForm(),
+                        "multiform": MultipleUploadFileForm(),
+                        "bulk_form": form,
+                    },
+                    # status=422  mandatory for Turbo: forces the display of validation errors (Turbo ignores 200 codes)
+                    status=422,
+                )
+
+            # Succes submit URL
+            BulkDocuments.objects.create(url=url, course=course, user=request.user)
+            success_url = (
+                reverse("document_submit_bulk", args=[course.slug]) + "?success=true"
             )
             return HttpResponseRedirect(success_url)
+
         else:
-            error_url = reverse(
-                "document_put", args=[course.slug], query={"error": "bulk"}
+            # Bad URL submit
+            return render(
+                request,
+                "documents/document_upload.html",
+                {
+                    "course": course,
+                    "form": UploadFileForm(),
+                    "multiform": MultipleUploadFileForm(),
+                    "bulk_form": form,
+                },
+                status=422,
             )
-            return HttpResponseRedirect(error_url)
 
     if "success" in request.GET:
         return render(


### PR DESCRIPTION
### Description
Following your feedback, I investigated the Turbo console error instead of just disabling Turbo. 

**The Problem:**
When the bulk upload form is submitted successfully, the `submit_bulk` view directly returns a `render()` (HTTP 200 OK). Hotwire Turbo strictly enforces the **Post/Redirect/Get (PRG)** pattern and throws the `Form responses must redirect to another location` error if a POST request doesn't return a redirect.

**The Implemented Solution (Current PR):**
I modified the `view.py` to respect the PRG pattern. 
1. On successful POST, it now returns an `HttpResponseRedirect` to the same URL, appending a `?success=1` parameter.
2. The view catches this GET parameter and renders the existing `document_bulk.html` success page.
*Result: The console is perfectly clean, and Turbo handles the navigation smoothly.*

---

### Alternative Idea for the Future (Option B)
While this PR fixes the bug using the current UI, having a dedicated success page (`document_bulk.html`) and `?success=1` in the URL might feel a bit heavy. 

As an alternative, we could completely remove this success page and use **Django Flash Messages** instead:
- After a successful POST, we redirect the user straight back to the course page (or the upload form).
- We display a global green success banner saying: *"Merci ! Ton lien a bien été envoyé aux administrateurs pour traitement."*

Let me know if you prefer to merge this PR as a quick fix, or if you'd like me to implement this "Flash Message" alternative instead!

---
**Manual Testing:**
- [x] Tested with a valid URL on local environment.
- [x] Verified that the Turbo console error is completely gone.

Fixes #369